### PR TITLE
i and 1 look too similar...

### DIFF
--- a/overlay/js/full_overlay.js
+++ b/overlay/js/full_overlay.js
@@ -501,7 +501,7 @@ function set_pos(elem, z, x) {
 }
 
 function player_join_number(i) {
-  return i + (1 % 5);
+  return 1 + (i % 5);
 }
 
 function set_number(elem, text) {

--- a/overlay/js/minimap.js
+++ b/overlay/js/minimap.js
@@ -19,7 +19,7 @@ sw.subscribe("frame_10hz", (data) => {
         player_data["head"]["position"][2],
         player_data["head"]["position"][0]
       );
-      set_number(player_numbers[i], "" + i + 1);
+      set_number(player_join_number(i));
       players[i].style.visibility = "visible";
     } else {
       set_pos(players[i], 0, 0);
@@ -46,9 +46,10 @@ function set_pos(elem, z, x) {
   elem.style.top = (x / 32 + 0.5) * 165 + 5 + "px";
 }
 
+function player_join_number(i) {
+  return 1 + (i % 5);
+}
+
 function set_number(elem, text) {
-  if (text.length === 1) {
-    text = "0" + text;
-  }
   elem.innerText = text;
 }


### PR DESCRIPTION
Fixes the minimap showing 1-10 instead of 1-5 for each team.
![image](https://github.com/DancingNerd/echo-master-league-overlays/assets/19482627/bdf1a42e-209b-4cc7-aa59-2a5f16bc88f3)

Note: I don't think the change to minimap.js did anything, but I added it for good measure.